### PR TITLE
Add Travis CI config to release built HTML book on tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: rust
+rust:
+  - nightly
+
+install:
+  - git clone --depth 1 https://github.com/steveklabnik/rustbook.git
+  - cargo build --release
+
+script:
+  - rustbook/target/release/rustbook build text/ book/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ install:
 
 script:
   - rustbook/target/release/rustbook build text/ book/
+  - tree book

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
 
 install:
   - git clone --depth 1 https://github.com/steveklabnik/rustbook.git
-  - cargo build --release
+  - cd rustbook && cargo build --release && cd ..
 
 script:
   - rustbook/target/release/rustbook build text/ book/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ install:
 
 script:
   - rustbook/target/release/rustbook build text/ book/
+
+after_success:
   - tree book

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: rust
 rust:
   - nightly
 
-before_install:
-  - apt-get install tree
+addons:
+  apt:
+    packages:
+      - tree
 
 install:
   - git clone --depth 1 https://github.com/steveklabnik/rustbook.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,12 @@ script:
 
 after_success:
   - tree book
-  - zip -r too-many-lists book
+  - zip -r too-many-lists.zip book
+
+deploy:
+  provider: releases
+  api_key: "$GH_DEPLOY_TOKEN"
+  file: "too-many-lists.zip"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ script:
 
 after_success:
   - tree book
+  - zip -r too-many-lists book

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: rust
 rust:
   - nightly
 
+before_install:
+  - apt-get install tree
+
 install:
   - git clone --depth 1 https://github.com/steveklabnik/rustbook.git
   - cd rustbook && cargo build --release && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
 
 after_success:
   - tree book
+  - zip too-many-lists.zip . -i *.css
   - zip -r too-many-lists.zip book
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ script:
   - rustbook/target/release/rustbook build text/ book/
 
 after_success:
-  - tree book
-  - zip too-many-lists.zip . -i *.css
+  - tree .
+  - zip too-many-lists.zip rust.css
   - zip -r too-many-lists.zip book
 
 deploy:


### PR DESCRIPTION
I think it is convenient to have an offline version of the book for download as well, so I wrote this Travis CI config to do that. With it Travis CI can take care of releasing a zip archive of the HTML book on tag. Creating a release on Github also triggers it to append the archive to the release.

Of course, you need to go to Travis CI to enable it for this repo. It also requires env var `GH_DEPLOY_TOKEN` be filled with a Github personal access token with "public_repo" enabled. This can be set in the Settings tab in the Travis CI page of this repo. 