### PR TITLE
Try to mutate peek, failing once in the process

### DIFF
--- a/lists/src/second.rs
+++ b/lists/src/second.rs
@@ -153,6 +153,13 @@ mod test {
 
         assert_eq!(list.peek(), Some(&3));
         assert_eq!(list.peek_mut(), Some(&mut 3));
+
+        list.peek_mut().map(|value| {
+            *value = 42 });
+
+        assert_eq!(list.peek(), Some(&42));
+        assert_eq!(list.pop(), Some(42));
+
     }
 
     #[test]

--- a/text/second-peek.md
+++ b/text/second-peek.md
@@ -103,7 +103,6 @@ fn peek() {
 }
 ```
 
-
 ```
 cargo test
    Compiling lists v0.1.0 (file:///Users/ABeingessner/dev/too-many-lists/lists)
@@ -122,3 +121,78 @@ running 0 tests
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
 ```
+
+That's nice, but we didn't really test to see if we could mutate that `peek_mut` return value, did we?  If a reference is mutable but nobody mutates it, have we really tested the mutability?  Let's try using `map` on this `Option<&mut T>` to put a profound value in:
+
+```rust
+#[test]
+fn peek() {
+    let mut list = List::new();
+    assert_eq!(list.peek(), None);
+    assert_eq!(list.peek_mut(), None);
+    list.push(1); list.push(2); list.push(3);
+
+    assert_eq!(list.peek(), Some(&3));
+    assert_eq!(list.peek_mut(), Some(&mut 3));
+    list.peek_mut().map(|&mut value| {
+        value = 42 });
+
+    assert_eq!(list.peek(), Some(&4));
+    assert_eq!(list.pop(), Some(42));
+}
+```
+
+```text
+> cargo test
+   Compiling lists v0.1.0 (file:///Users/ABeingessner/dev/too-many-lists/lists)
+src/second.rs:158:13: 158:23 error: re-assignment of immutable variable `value` [E0384]
+src/second.rs:158             value = 42 });
+                              ^~~~~~~~~~
+src/second.rs:158:13: 158:23 help: run `rustc --explain E0384` to see a detailed explanation
+src/second.rs:157:35: 157:40 note: prior assignment occurs here
+src/second.rs:157         list.peek_mut().map(|&mut value| {
+                                                    ^~~~~
+error: aborting due to previous error
+```
+
+The compiler is complaining that `value` is immutable, but we pretty clearly wrote `&mut value`; what gives?  It turns out that writing the argument of the closure that way doesn't specify that `value` is a mutable reference but instead creates a pattern that will be matched against the argument to the closure; `|&mut value|` means "the argument is a mutable reference, but just stick the immutable value into `value`, please."  If we just use `|value|`, the type of `value` will be `&mut i32` and we can actually mutate the head:
+
+```rust
+    #[test]
+    fn peek() {
+        let mut list = List::new();
+        assert_eq!(list.peek(), None);
+        assert_eq!(list.peek_mut(), None);
+        list.push(1); list.push(2); list.push(3);
+
+        assert_eq!(list.peek(), Some(&3));
+        assert_eq!(list.peek_mut(), Some(&mut 3));
+
+        list.peek_mut().map(|value| {
+            *value = 42 });
+
+        assert_eq!(list.peek(), Some(&42));
+        assert_eq!(list.pop(), Some(42));
+    }
+```
+
+```text
+cargo test
+   Compiling lists v0.1.0 (file:///Users/ABeingessner/dev/too-many-lists/lists)
+     Running target/debug/lists-5c71138492ad4b4a
+
+running 3 tests
+test first::test::basics ... ok
+test second::test::basics ... ok
+test second::test::peek ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured
+
+   Doc-tests lists
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
+```
+
+Much better!


### PR DESCRIPTION
This commit fixes #44.  I wondered the same thing and made some of the same mistakes as @alopatindev before stumbling on a way to mutate the reference inside of the `Option` returned by `peek_mut`.