### PR TITLE
Fix typo, add "mut"

### DIFF
--- a/src/second-iter-mut.md
+++ b/src/second-iter-mut.md
@@ -60,7 +60,7 @@ pub struct IterMut<'a, T: 'a> {
 }
 
 impl<T> List<T> {
-    pub fn iter_mut(&self) -> IterMut<T> {
+    pub fn iter_mut(&mut self) -> IterMut<T> {
         IterMut { next: self.head.as_mut().map(|node| &mut **node) }
     }
 }


### PR DESCRIPTION
Thank you for the book.
Here is one mistake that was found while reading "An ok stack: 3.6 IterMut". 
Compiler errors log described next to the code appears if `self` borrowed as `&mut`.
But in "3.7 Final Code" that moment is correct