### PR TITLE
Update README to use mdbook over rustbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-book
-text/_book
+book/

--- a/README.md
+++ b/README.md
@@ -1,49 +1,20 @@
-# Learn Rust by writing Entirely Too Many linked lists [![Build Status](https://travis-ci.org/rust-unofficial/too-many-lists.svg?branch=master)](https://travis-ci.org/rust-unofficial/too-many-lists)
+# Learn Rust by writing Entirely Too Many Linked Lists
+[![Build Status](https://travis-ci.org/rust-unofficial/too-many-lists.svg?branch=master)](https://travis-ci.org/rust-unofficial/too-many-lists)
 
-Read the pretty version at http://cglab.ca/~abeinges/blah/too-many-lists/book/
+Read the pretty version at [http://cglab.ca/~abeinges/blah/too-many-lists/book/](http://cglab.ca/~abeinges/blah/too-many-lists/book/).
 
 # Building
 
-Building requires an instance of rustbook be set up on your machine.
-
-A mirror of the rustbook code can be found [here](https://github.com/steveklabnik/rustbook).
-This requires a nightly version of the Rust compiler, as well as Cargo:
+Building requires mdbook, which can be installed from crates.io:
 
 ```sh
-cd rustbook/
-cargo build --release
+cargo install mdbook
 ```
 
-Once built, the binary can be found at `rustbook/target/release/rustbook`.
-
----
-
-If that doesn't work (#13), rustbook can also be built as part of rustc.
-Here's instructions for
-[building Rust from source](https://github.com/rust-lang/rust/#building-from-source).
-
-However it needs to be a slight deviation from the normal process:
-
-* You should do `./configure --enable-rpath` instead of `./configure`
-* You don't need to `install` (I don't think rustbook will use that -- although
-  maybe I'm wrong and make install will install rustbook too -- happy to be wrong!)
-
-Once built, rustbook will be somewhere deep in the build target
-directories. This is a bit platform-specific, to be honest. On my
-machine it's at `x86_64-apple-darwin/stage2/bin/rustbook`. The
-`x86_64-apple-darwin` bit is the *really* platform specific part,
-where I hope you can guess what your platform will sort of look
-like. On windows you may need to look in stage3.
-
-Now just copy or link rustbook to be somewhere on your path.
-
----
-
-Once you have the rustbook binary, you just need to do:
+Assuming you've placed `mdbook` into your system PATH variable, then run it from the root of your local copy:
 
 ```sh
-cd too-many-lists/
-rm -rf book/ && rustbook build text/ book/
+mdbook build
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Building requires mdbook, which can be installed from crates.io:
 cargo install mdbook
 ```
 
-Assuming you've placed `mdbook` into your system PATH variable, then run it from the root of your local copy:
+Assuming you've placed the install directory `~/.cargo/bin` into your system PATH, then run from the root of your local copy:
 
 ```sh
 mdbook build


### PR DESCRIPTION
Rustbook has been largely [re-implemented](https://github.com/rust-lang/rust/tree/master/src/tools/rustbook) in terms of [mdBook](https://github.com/azerupi/mdBook), the rust books have been [ported](https://github.com/rust-lang/rust/pull/39633) to mdBook, and the README's install instructions are wildly out of date by now.

I'd like to propose changing the build instructions to use mdBook, which appears to be better-maintained, at least because `cargo install mdbook` is a little simpler than cloning and building rustbook.

The build process is about the same and works just as well as rustbook did.