### PR TITLE
add `mut` to corrected iter_mut definition

### DIFF
--- a/src/second-iter-mut.md
+++ b/src/second-iter-mut.md
@@ -98,7 +98,7 @@ though, it even tells us how to fix it! You can't upgrade a shared reference to 
 one, so `iter_mut` needs to take `&mut self`. Just a silly copy-paste error.
 
 ```rust ,ignore
-pub fn iter_mut(&self) -> IterMut<'_, T> {
+pub fn iter_mut(&mut self) -> IterMut<'_, T> {
     IterMut { next: self.head.as_mut().map(|node| &mut **node) }
 }
 ```


### PR DESCRIPTION
I believe the corrected version was intended to be shown, but it looks like there was a `mut` missing. Must have been a silly copy-paste error 😄 