### PR TITLE
fix issue 113: missing borrow in example code section 5.6

### DIFF
--- a/src/fourth-iteration.md
+++ b/src/fourth-iteration.md
@@ -188,7 +188,7 @@ fn next(&mut self) -> Option<Self::Item> {
             (&node.next, &node.elem)
         });
 
-        self.0 = next.as_ref().map(|head| head);
+        self.0 = next.as_ref().map(|head| head.borrow());
 
         elem
     })


### PR DESCRIPTION
Fix for https://github.com/rust-unofficial/too-many-lists/issues/113