### PR TITLE
remove `lists::` -- I assume this is a typo

### DIFF
--- a/src/second-iter.md
+++ b/src/second-iter.md
@@ -442,7 +442,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 ```
 
 ```text
-lists::cargo build
+cargo build
 
 ```
 


### PR DESCRIPTION
Remove `lists::` from cargo build command