### PR TITLE
remove extra text from the test command

### DIFF
--- a/src/third-drop.md
+++ b/src/third-drop.md
@@ -48,7 +48,7 @@ impl<T> Drop for List<T> {
 ```
 
 ```text
-src::cargo test
+cargo test
    Compiling lists v0.1.0 (/Users/ABeingessner/dev/too-many-lists/lists)
     Finished dev [unoptimized + debuginfo] target(s) in 1.10s
      Running /Users/ABeingessner/dev/too-many-lists/lists/target/debug/deps/lists-86544f1d97438f1f


### PR DESCRIPTION
Remove `src::` from the `cargo test` command.