### PR TITLE
Copy and paste strikes again!

### DIFF
--- a/src/fourth-symmetry.md
+++ b/src/fourth-symmetry.md
@@ -117,7 +117,6 @@ fn basics() {
     assert_eq!(list.pop_back(), Some(4));
 
     // Check exhaustion
-    assert_eq!(list.pop_back(), Some(1));
     assert_eq!(list.pop_back(), None);
 }
 


### PR DESCRIPTION
Remove extra `pop_back()` since the value `1` was already removed by `pop_front()`