### PR TITLE
feat(first-drop): Simplify loop and let rust use partial moves

### DIFF
--- a/src/first-drop.md
+++ b/src/first-drop.md
@@ -87,8 +87,8 @@ impl Drop for List {
     fn drop(&mut self) {
         let mut cur_link = mem::replace(&mut self.head, Link::Empty);
         // `while let` == "do this thing until this pattern doesn't match"
-        while let Link::More(mut boxed_node) = cur_link {
-            cur_link = mem::replace(&mut boxed_node.next, Link::Empty);
+        while let Link::More(boxed_node) = cur_link {
+            cur_link = boxed_node.next;
             // boxed_node goes out of scope and gets dropped here;
             // but its Node's `next` field has been set to Link::Empty
             // so no unbounded recursion occurs.


### PR DESCRIPTION
The drop function does not need to use mem::replace in the while loop. A more concise expression is possible.