### PR TITLE
Fix typo in Layout section of persistent list

### DIFF
--- a/src/third-layout.md
+++ b/src/third-layout.md
@@ -127,7 +127,7 @@ warning: field is never used: `next`
    |     ^^^^^^^^^^^^^
 ```
 
-Seems legit. Rust continues to be a *completely* trivial to write. I bet we can just
+Seems legit. Rust continues to be *completely* trivial to write. I bet we can just
 find-and-replace Box with Rc and call it a day!
 
 ...


### PR DESCRIPTION
**This PR**
Just fixes a small typo at the end of the "Layout" section for the persistent linked list.