### PR TITLE
Updating to make use of Rust 1.40 as_deref() and as_deref_mut()

### DIFF
--- a/lists/src/fifth.rs
+++ b/lists/src/fifth.rs
@@ -66,11 +66,11 @@ impl<T> List<T> {
     }
 
     pub fn iter(&self) -> Iter<'_, T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
-        IterMut { next: self.head.as_mut().map(|node| &mut **node) }
+        IterMut { next: self.head.as_deref_mut() }
     }
 }
 
@@ -105,7 +105,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.map(|node| {
-            self.next = node.next.as_ref().map(|node| &**node);
+            self.next = node.next.as_deref();
             &node.elem
         })
     }
@@ -116,7 +116,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.take().map(|node| {
-            self.next = node.next.as_mut().map(|node| &mut **node);
+            self.next = node.next.as_deref_mut();
             &mut node.elem
         })
     }

--- a/lists/src/second.rs
+++ b/lists/src/second.rs
@@ -47,7 +47,7 @@ impl<T> List<T> {
     }
 
     pub fn iter(&self) -> Iter<'_, T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 }
 
@@ -77,7 +77,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
     fn next(&mut self) -> Option<Self::Item> {
         self.next.map(|node| {
-            self.next = node.next.as_ref().map(|node| &**node);
+            self.next = node.next.as_deref();
             &node.elem
         })
     }
@@ -89,7 +89,7 @@ pub struct IterMut<'a, T: 'a> {
 
 impl<T> List<T> {
     pub fn iter_mut(&mut self) -> IterMut<T> {
-        IterMut { next: self.head.as_mut().map(|node| &mut **node) }
+        IterMut { next: self.head.as_deref_mut() }
     }
 }
 
@@ -98,7 +98,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.take().map(|node| {
-            self.next = node.next.as_mut().map(|node| &mut **node);
+            self.next = node.next.as_deref_mut();
             &mut node.elem
         })
     }

--- a/lists/src/third.rs
+++ b/lists/src/third.rs
@@ -32,7 +32,7 @@ impl<T> List<T> {
     }
 
     pub fn iter(&self) -> Iter<'_, T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 }
 
@@ -58,7 +58,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.map(|node| {
-            self.next = node.next.as_ref().map(|node| &**node);
+            self.next = node.next.as_deref();
             &node.elem
         })
     }

--- a/src/fifth-extras.md
+++ b/src/fifth-extras.md
@@ -43,11 +43,11 @@ impl<T> List<T> {
     }
 
     pub fn iter(&self) -> Iter<'_, T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
-        IterMut { next: self.head.as_mut().map(|node| &mut **node) }
+        IterMut { next: self.head.as_deref_mut() }
     }
 }
 
@@ -72,7 +72,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.map(|node| {
-            self.next = node.next.as_ref().map(|node| &**node);
+            self.next = node.next.as_deref();
             &node.elem
         })
     }
@@ -83,7 +83,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.take().map(|node| {
-            self.next = node.next.as_mut().map(|node| &mut **node);
+            self.next = node.next.as_deref_mut();
             &mut node.elem
         })
     }

--- a/src/fifth-final.md
+++ b/src/fifth-final.md
@@ -75,11 +75,11 @@ impl<T> List<T> {
     }
 
     pub fn iter(&self) -> Iter<'_, T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
-        IterMut { next: self.head.as_mut().map(|node| &mut **node) }
+        IterMut { next: self.head.as_deref_mut() }
     }
 }
 
@@ -114,7 +114,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.map(|node| {
-            self.next = node.next.as_ref().map(|node| &**node);
+            self.next = node.next.as_deref();
             &node.elem
         })
     }
@@ -125,7 +125,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.take().map(|node| {
-            self.next = node.next.as_mut().map(|node| &mut **node);
+            self.next = node.next.as_deref_mut();
             &mut node.elem
         })
     }

--- a/src/fifth-layout.md
+++ b/src/fifth-layout.md
@@ -172,12 +172,12 @@ impl<T> List<T> {
             Some(old_tail) => {
                 // If the old tail existed, update it to point to the new tail
                 old_tail.next = Some(new_tail);
-                old_tail.next.as_mut().map(|node| &mut **node)
+                old_tail.next.as_deref_mut()
             }
             None => {
                 // Otherwise, update the head to point to it
                 self.head = Some(new_tail);
-                self.head.as_mut().map(|node| &mut **node)
+                self.head.as_deref_mut()
             }
         };
 
@@ -234,12 +234,12 @@ impl<'a, T> List<'a, T> {
             Some(old_tail) => {
                 // If the old tail existed, update it to point to the new tail
                 old_tail.next = Some(new_tail);
-                old_tail.next.as_mut().map(|node| &mut **node)
+                old_tail.next.as_deref_mut()
             }
             None => {
                 // Otherwise, update the head to point to it
                 self.head = Some(new_tail);
-                self.head.as_mut().map(|node| &mut **node)
+                self.head.as_deref_mut()
             }
         };
 
@@ -254,8 +254,8 @@ cargo build
 error[E0495]: cannot infer an appropriate lifetime for autoref due to conflicting requirements
   --> src/fifth.rs:35:27
    |
-35 |                 self.head.as_mut().map(|node| &mut **node)
-   |                           ^^^^^^
+35 |                 self.head.as_deref_mut()
+   |                           ^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the method body at 18:5...
   --> src/fifth.rs:18:5
@@ -271,7 +271,7 @@ note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on th
 note: ...so that reference does not outlive borrowed content
   --> src/fifth.rs:35:17
    |
-35 |                 self.head.as_mut().map(|node| &mut **node)
+35 |                 self.head.as_deref_mut()
    |                 ^^^^^^^^^
 note: but, the lifetime must be valid for the lifetime 'a as defined on the impl at 13:6...
   --> src/fifth.rs:13:6

--- a/src/second-final.md
+++ b/src/second-final.md
@@ -52,11 +52,11 @@ impl<T> List<T> {
     }
 
     pub fn iter(&self) -> Iter<'_, T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
-        IterMut { next: self.head.as_mut().map(|node| &mut **node) }
+        IterMut { next: self.head.as_deref_mut() }
     }
 }
 
@@ -87,7 +87,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
     fn next(&mut self) -> Option<Self::Item> {
         self.next.map(|node| {
-            self.next = node.next.as_ref().map(|node| &**node);
+            self.next = node.next.as_deref();
             &node.elem
         })
     }
@@ -102,7 +102,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.take().map(|node| {
-            self.next = node.next.as_mut().map(|node| &mut **node);
+            self.next = node.next.as_deref_mut();
             &mut node.elem
         })
     }

--- a/src/second-iter-mut.md
+++ b/src/second-iter-mut.md
@@ -60,7 +60,7 @@ pub struct IterMut<'a, T> {
 
 impl<T> List<T> {
     pub fn iter_mut(&self) -> IterMut<'_, T> {
-        IterMut { next: self.head.as_mut().map(|node| &mut **node) }
+        IterMut { next: self.head.as_deref_mut() }
     }
 }
 
@@ -69,7 +69,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.map(|node| {
-            self.next = node.next.as_mut().map(|node| &mut **node);
+            self.next = node.next.as_deref_mut();
             &mut node.elem
         })
     }
@@ -83,7 +83,7 @@ error[E0596]: cannot borrow `self.head` as mutable, as it is behind a `&` refere
    |
 94 |     pub fn iter_mut(&self) -> IterMut<'_, T> {
    |                     ----- help: consider changing this to be a mutable reference: `&mut self`
-95 |         IterMut { next: self.head.as_mut().map(|node| &mut **node) }
+95 |         IterMut { next: self.head.as_deref_mut() }
    |                         ^^^^^^^^^ `self` is a `&` reference, so the data it refers to cannot be borrowed as mutable
 
 error[E0507]: cannot move out of borrowed content
@@ -99,7 +99,7 @@ one, so `iter_mut` needs to take `&mut self`. Just a silly copy-paste error.
 
 ```rust ,ignore
 pub fn iter_mut(&mut self) -> IterMut<'_, T> {
-    IterMut { next: self.head.as_mut().map(|node| &mut **node) }
+    IterMut { next: self.head.as_deref_mut() }
 }
 ```
 
@@ -136,7 +136,7 @@ the Option to get it.
 ```rust ,ignore
 fn next(&mut self) -> Option<Self::Item> {
     self.next.take().map(|node| {
-        self.next = node.next.as_mut().map(|node| &mut **node);
+        self.next = node.next.as_deref_mut();
         &mut node.elem
     })
 }

--- a/src/second-iter.md
+++ b/src/second-iter.md
@@ -425,7 +425,7 @@ pub struct Iter<'a, T> {
 
 impl<T> List<T> {
     pub fn iter<'a>(&'a self) -> Iter<'a, T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 }
 
@@ -434,7 +434,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.map(|node| {
-            self.next = node.next.as_ref().map(|node| &**node);
+            self.next = node.next.as_deref();
             &node.elem
         })
     }
@@ -448,7 +448,10 @@ cargo build
 
 🎉 🎉 🎉
 
-You may be thinking "wow that `&**` thing is really janky", and you're not wrong.
+The as_deref and as-derf_mut functions are stable as of Rust 1.40. Before that you
+would need to do `map(|node| &**node)` and `map(|node| &mut**node)`.
+You may be thinking "wow that `&**` thing is really janky", and you're not wrong,
+but like a fine wine rust gets better over time and we no longer need to do such.
 Normally Rust is very good at doing this kind of conversion implicitly, through
 a process called *deref coercion*, where basically it can insert \*'s
 throughout your code to make it type-check. It can do this because we have the
@@ -456,7 +459,7 @@ borrow checker to ensure we never mess up pointers!
 
 But in this case the closure in conjunction with the fact that we
 have an `Option<&T>` instead of `&T` is a bit too complicated for it to work
-out, so we need to do this for it. Thankfully this is pretty rare, in my experience.
+out, so we need to help it by being explicit. Thankfully this is pretty rare, in my experience.
 
 Just for completeness' sake, we *could* give it a *different* hint with the *turbofish*:
 
@@ -518,7 +521,7 @@ Finally, it should be noted that we *can* actually apply lifetime elision here:
 ```rust ,ignore
 impl<T> List<T> {
     pub fn iter<'a>(&'a self) -> Iter<'a, T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 }
 ```
@@ -528,7 +531,7 @@ is equivalent to:
 ```rust ,ignore
 impl<T> List<T> {
     pub fn iter(&self) -> Iter<T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 }
 ```
@@ -541,7 +544,7 @@ you can use the Rust 2018 "explicitly elided lifetime" syntax,  `'_`:
 ```rust ,ignore
 impl<T> List<T> {
     pub fn iter(&self) -> Iter<'_, T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 }
 ```

--- a/src/third-basics.md
+++ b/src/third-basics.md
@@ -180,7 +180,7 @@ pub struct Iter<'a, T> {
 
 impl<T> List<T> {
     pub fn iter(&self) -> Iter<'_, T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 }
 
@@ -189,7 +189,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.map(|node| {
-            self.next = node.next.as_ref().map(|node| &**node);
+            self.next = node.next.as_deref();
             &node.elem
         })
     }

--- a/src/third-final.md
+++ b/src/third-final.md
@@ -38,7 +38,7 @@ impl<T> List<T> {
     }
 
     pub fn iter(&self) -> Iter<'_, T> {
-        Iter { next: self.head.as_ref().map(|node| &**node) }
+        Iter { next: self.head.as_deref() }
     }
 }
 
@@ -64,7 +64,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next.map(|node| {
-            self.next = node.next.as_ref().map(|node| &**node);
+            self.next = node.next.as_deref();
             &node.elem
         })
     }


### PR DESCRIPTION
This update simplifys things thanks to rust 1.40 and now lists look a lot less scary for beginners. 
(Fixes #154 )