### PR TITLE
Grammar and spelling fixes

### DIFF
--- a/src/fifth-layout.md
+++ b/src/fifth-layout.md
@@ -424,7 +424,7 @@ cardinal Rust sin: we stored a reference to ourselves *inside ourselves*.
 Somehow, we managed to convince Rust that this totally made sense in our
 `push` and `pop` implementations (I was legitimately shocked we did). I believe
 the reason is that Rust can't yet tell that the reference is into ourselves
-from just `push` and `pop` -- or rather, Rust doesn't really have that notion
+from just `push` and `pop` &emdash; or rather, Rust doesn't really have that notion
 at all. Reference-into-yourself failing to work is just an emergent behaviour.
 
 As soon as we tried to *use* our list, everything quickly fell apart.

--- a/src/fifth-unsafe.md
+++ b/src/fifth-unsafe.md
@@ -37,7 +37,7 @@ be `const T*` and `T*` from C, but we really don't care about what C thinks they
 mean that much. You can only dereference a `*const T` to an `&T`, but much like
 the mutability of a variable, this is just a lint against incorrect usage. At
 most it just means you have to cast the `*const` to a `*mut` first. Although if
-you don't actually have permission to mutate the referrent of the pointer,
+you don't actually have permission to mutate the referent of the pointer,
 you're gonna have a bad time.
 
 Anyway, we'll get a better feel for this as we write some code. For now,

--- a/src/first-push.md
+++ b/src/first-push.md
@@ -11,7 +11,7 @@ impl List {
 }
 ```
 
-First thing's first, we need to make a node to store our element in:
+First things first, we need to make a node to store our element in:
 
 ```rust ,ignore
     pub fn push(&mut self, elem: i32) {

--- a/src/second-iter-mut.md
+++ b/src/second-iter-mut.md
@@ -16,7 +16,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
 }
 ```
 
-Which can be desugarred to:
+Which can be desugared to:
 
 ```rust ,ignore
 impl<'a, T> Iterator for Iter<'a, T> {
@@ -121,7 +121,7 @@ As such, they have a super power: when moved, the old value *is* still usable.
 As a consequence, you can even move a Copy type out of a reference without
 replacement!
 
-All numeric primitives in rust (i32, u64, bool, f32, char, etc...) are Copy.
+All numeric primitives in Rust (i32, u64, bool, f32, char, etc...) are Copy.
 You can also declare any user-defined type to be Copy as well, as long as
 all its components are Copy.
 

--- a/src/second-iter.md
+++ b/src/second-iter.md
@@ -448,7 +448,7 @@ cargo build
 
 🎉 🎉 🎉
 
-The as_deref and as_derf_mut functions are stable as of Rust 1.40. Before that you
+The as_deref and as_deref_mut functions are stable as of Rust 1.40. Before that you
 would need to do `map(|node| &**node)` and `map(|node| &mut**node)`.
 You may be thinking "wow that `&**` thing is really janky", and you're not wrong,
 but like a fine wine Rust gets better over time and we no longer need to do such.

--- a/src/second-iter.md
+++ b/src/second-iter.md
@@ -184,7 +184,7 @@ something didn't live long enough.
 
 Within a function body you generally can't talk about lifetimes, and wouldn't
 want to *anyway*. The compiler has full information and can infer all the
-contraints to find the minimum lifetimes. However at the type and API-level,
+constraints to find the minimum lifetimes. However at the type and API-level,
 the compiler *doesn't* have all the information. It requires you to tell it
 about the relationship between different lifetimes so it can figure out what
 you're doing.
@@ -448,10 +448,10 @@ cargo build
 
 🎉 🎉 🎉
 
-The as_deref and as-derf_mut functions are stable as of Rust 1.40. Before that you
+The as_deref and as_derf_mut functions are stable as of Rust 1.40. Before that you
 would need to do `map(|node| &**node)` and `map(|node| &mut**node)`.
 You may be thinking "wow that `&**` thing is really janky", and you're not wrong,
-but like a fine wine rust gets better over time and we no longer need to do such.
+but like a fine wine Rust gets better over time and we no longer need to do such.
 Normally Rust is very good at doing this kind of conversion implicitly, through
 a process called *deref coercion*, where basically it can insert \*'s
 throughout your code to make it type-check. It can do this because we have the

--- a/src/third-layout.md
+++ b/src/third-layout.md
@@ -30,7 +30,7 @@ This just can't work with Boxes, because ownership of `B` is *shared*. Who
 should free it? If I drop list2, does it free B? With boxes we certainly would
 expect so!
 
-Functional languages -- and indeed almost every other language -- get away with
+Functional languages &emdash; and indeed almost every other language &emdash; get away with
 this by using *garbage collection*. With the magic of garbage collection, B will
 be freed only after everyone stops looking at it. Hooray!
 
@@ -41,7 +41,7 @@ Rust has today is *reference counting*. Reference counting can be thought of
 as a very simple GC. For many workloads, it has significantly less throughput
 than a tracing collector, and it completely falls over if you manage to
 build cycles. But hey, it's all we've got! Thankfully, for our usecase we'll never run into cycles
-(feel free to try to prove this to yourself -- I sure won't).
+(feel free to try to prove this to yourself &emdash; I sure won't).
 
 So how do we do reference-counted garbage collection? `Rc`! Rc is just like
 Box, but we can duplicate it, and its memory will *only* be freed when *all*


### PR DESCRIPTION
* capitalise Rust when it's a proper noun
* replace -- with — html entity (all usages are em dashes)
* remove apostrophe in "First things first"
* small typos