### PR TITLE
Add better tests for IterMut

### DIFF
--- a/src/second-final.md
+++ b/src/second-final.md
@@ -187,10 +187,11 @@ mod test {
         let mut list = List::new();
         list.push(1); list.push(2); list.push(3);
 
+        list.iter_mut().for_each(|i| *i += 1);
         let mut iter = list.iter_mut();
+        assert_eq!(iter.next(), Some(&mut 4));
         assert_eq!(iter.next(), Some(&mut 3));
         assert_eq!(iter.next(), Some(&mut 2));
-        assert_eq!(iter.next(), Some(&mut 1));
     }
 }
 

--- a/src/second-iter-mut.md
+++ b/src/second-iter-mut.md
@@ -158,10 +158,11 @@ fn iter_mut() {
     let mut list = List::new();
     list.push(1); list.push(2); list.push(3);
 
+    list.iter_mut().for_each(|i| *i += 1);
     let mut iter = list.iter_mut();
+    assert_eq!(iter.next(), Some(&mut 4));
     assert_eq!(iter.next(), Some(&mut 3));
     assert_eq!(iter.next(), Some(&mut 2));
-    assert_eq!(iter.next(), Some(&mut 1));
 }
 ```
 


### PR DESCRIPTION
`iter_mut` can be used to modify the content of List, add a better test case for it.