### PR TITLE
Replace emdash with mdash

### DIFF
--- a/src/fifth-layout.md
+++ b/src/fifth-layout.md
@@ -424,7 +424,7 @@ cardinal Rust sin: we stored a reference to ourselves *inside ourselves*.
 Somehow, we managed to convince Rust that this totally made sense in our
 `push` and `pop` implementations (I was legitimately shocked we did). I believe
 the reason is that Rust can't yet tell that the reference is into ourselves
-from just `push` and `pop` &emdash; or rather, Rust doesn't really have that notion
+from just `push` and `pop` &mdash; or rather, Rust doesn't really have that notion
 at all. Reference-into-yourself failing to work is just an emergent behaviour.
 
 As soon as we tried to *use* our list, everything quickly fell apart.

--- a/src/third-layout.md
+++ b/src/third-layout.md
@@ -30,7 +30,7 @@ This just can't work with Boxes, because ownership of `B` is *shared*. Who
 should free it? If I drop list2, does it free B? With boxes we certainly would
 expect so!
 
-Functional languages &emdash; and indeed almost every other language &emdash; get away with
+Functional languages &mdash; and indeed almost every other language &mdash; get away with
 this by using *garbage collection*. With the magic of garbage collection, B will
 be freed only after everyone stops looking at it. Hooray!
 
@@ -41,7 +41,7 @@ Rust has today is *reference counting*. Reference counting can be thought of
 as a very simple GC. For many workloads, it has significantly less throughput
 than a tracing collector, and it completely falls over if you manage to
 build cycles. But hey, it's all we've got! Thankfully, for our usecase we'll never run into cycles
-(feel free to try to prove this to yourself &emdash; I sure won't).
+(feel free to try to prove this to yourself &mdash; I sure won't).
 
 So how do we do reference-counted garbage collection? `Rc`! Rc is just like
 Box, but we can duplicate it, and its memory will *only* be freed when *all*


### PR DESCRIPTION
The &emdash; directives were showing up in the text uninterpreted. I changed them to &mdash; and now they correctly produce a long dash in the text.