### PR TITLE
Use literal "—", not "&emdash;"

### DIFF
--- a/src/fifth-layout.md
+++ b/src/fifth-layout.md
@@ -424,7 +424,7 @@ cardinal Rust sin: we stored a reference to ourselves *inside ourselves*.
 Somehow, we managed to convince Rust that this totally made sense in our
 `push` and `pop` implementations (I was legitimately shocked we did). I believe
 the reason is that Rust can't yet tell that the reference is into ourselves
-from just `push` and `pop` &emdash; or rather, Rust doesn't really have that notion
+from just `push` and `pop` — or rather, Rust doesn't really have that notion
 at all. Reference-into-yourself failing to work is just an emergent behaviour.
 
 As soon as we tried to *use* our list, everything quickly fell apart.

--- a/src/third-layout.md
+++ b/src/third-layout.md
@@ -30,7 +30,7 @@ This just can't work with Boxes, because ownership of `B` is *shared*. Who
 should free it? If I drop list2, does it free B? With boxes we certainly would
 expect so!
 
-Functional languages &emdash; and indeed almost every other language &emdash; get away with
+Functional languages — and indeed almost every other language — get away with
 this by using *garbage collection*. With the magic of garbage collection, B will
 be freed only after everyone stops looking at it. Hooray!
 


### PR DESCRIPTION
Evidently our Markdown processor doesn't recognize `&emdash;`, and
prints it as `&amp;emdash;` in the HTML.