### PR TITLE
Type name not rendered correctly without backticks

### DIFF
--- a/src/second-peek.md
+++ b/src/second-peek.md
@@ -44,7 +44,7 @@ impl<T> Option<T> {
 }
 ```
 
-It demotes the Option<T> to an Option to a reference to its internals. We could
+It demotes the `Option<T>` to an Option to a reference to its internals. We could
 do this ourselves with an explicit match but *ugh no*. It does mean that we
 need to do an extra dereference to cut through the extra indirection, but
 thankfully the `.` operator handles that for us.


### PR DESCRIPTION
That causes an invalid ePub file rendered by `mdbook-epub`.