### PR TITLE
Fix compilation error and typos

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -221,7 +221,7 @@ recursively, and also work with infinite lists due to the magic of laziness.
 Specifically, linked lists are nice because they represent an iteration without
 the need for any mutable state. The next step is just visiting the next sublist.
 
-Rust most does this kind of thing with [iterators][]. They can be infinite 
+Rust mostly does this kind of thing with [iterators][]. They can be infinite 
 and you can map, filter, reverse, and concatenate them just like a functional list,
 and it will all be done just as lazily!
 

--- a/src/fifth-extras.md
+++ b/src/fifth-extras.md
@@ -155,10 +155,12 @@ impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.next.map(|node| {
-            self.next = node.next.as_deref();
-            &node.elem
-        })
+        unsafe {
+            self.next.map(|node| {
+                self.next = node.next.as_ref();
+                &node.elem
+            })
+        }
     }
 }
 
@@ -166,10 +168,12 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.next.take().map(|node| {
-            self.next = node.next.as_deref_mut();
-            &mut node.elem
-        })
+        unsafe {
+            self.next.take().map(|node| {
+                self.next = node.next.as_mut();
+                &mut node.elem
+            })
+        }
     }
 }
 ```

--- a/src/fifth-layout.md
+++ b/src/fifth-layout.md
@@ -333,6 +333,7 @@ pub fn pop(&'a mut self) -> Option<T> {
 And write a quick test for that:
 
 ```rust ,ignore
+#[cfg(test)]
 mod test {
     use super::List;
     #[test]

--- a/src/fourth-iteration.md
+++ b/src/fourth-iteration.md
@@ -18,7 +18,7 @@ impl<T> List<T> {
 
 impl<T> Iterator for IntoIter<T> {
     type Item = T;
-    fn next(&mut self) -> Option<T> {
+    fn next(&mut self) -> Option<Self::Item> {
         self.0.pop_front()
     }
 }

--- a/src/third-basics.md
+++ b/src/third-basics.md
@@ -109,7 +109,7 @@ reference to the first element. That's just `peek` from the mutable list:
 
 ```rust ,ignore
 pub fn head(&self) -> Option<&T> {
-    self.head.as_ref().map(|node| &node.elem )
+    self.head.as_ref().map(|node| &node.elem)
 }
 ```
 


### PR DESCRIPTION
This makes a few minor changes I noticed as I was working through the book. The typos themselves are very minor (extra/missing spaces). The actual code changes are in separate commits; one of the `mod tests` was missing a `#[cfg(test)]` and a code snippet from towards the end of the Unsafe Queue didn't compile (nor match the same snippet from the Final Code for the section) without prose explaining that it is an expected failure.