### PR TITLE
Add copied code inside of citation

### DIFF
--- a/src/first-layout.md
+++ b/src/first-layout.md
@@ -80,20 +80,20 @@ Lesse here...
 >
 > Creating a recursive data structure:
 >
-```rust
-#[derive(Debug)]
-enum List<T> {
-    Cons(T, Box<List<T>>),
-    Nil,
-}
-```
+> ```rust
+> #[derive(Debug)]
+> enum List<T> {
+>     Cons(T, Box<List<T>>),
+>     Nil,
+> }
+> ```
 >
-```rust ,ignore
-fn main() {
-    let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::new(List::Nil))));
-    println!("{:?}", list);
-}
-```
+> ```rust ,ignore
+> fn main() {
+>     let list: List<i32> = List::Cons(1, Box::new(List::Cons(2, Box::new(List::Nil))));
+>     println!("{:?}", list);
+> }
+> ```
 >
 > This will print `Cons(1, Box(Cons(2, Box(Nil))))`.
 >


### PR DESCRIPTION
On first read, it was far from clear which part of the code was copy-pasted and which part was actually what you suggest us to try in your first-implementation of linked-list.
Personally, I failed to understand why you suddenly renamed Empty and Elem to Cons and Nil, and while you went from i32 to generic type. It become clear only when I realized that below, you moved back to an enum with the constructor names you first used and that the code came from the documentation.