### PR TITLE
Adding `where` after `map`'s type

### DIFF
--- a/src/second-iter.md
+++ b/src/second-iter.md
@@ -471,6 +471,8 @@ See, map is a generic function:
 
 ```rust ,ignore
 pub fn map<U, F>(self, f: F) -> Option<U>
+where
+  F: FnOnce(T) -> U
 ```
 
 The turbofish, `::<>`, lets us tell the compiler what we think the types of those


### PR DESCRIPTION
On first read, I was extremely confused about this clarification. I could not understand how map was producing this U, while F had a type with no constraint at all. I had to look at map's documentation to figure out that actually F is constrained.
To avoid this confusion for other reader, I think that adding this part of the definition is helpful.

While one can argue that it does not matter since the turbofish don't constrain F, I'd argue that as long as F is explicitly written down, it matters for the sake of clarity. Another solution would be to hide F from the type here and replace it by a symbol indicating that we can ignore it. But I believe that it would complexify things uselessly, since as far as I understand, it could not be done in valid Rust