### PR TITLE
Making second.rs and second-final consistent

### DIFF
--- a/lists/src/second.rs
+++ b/lists/src/second.rs
@@ -46,8 +46,12 @@ impl<T> List<T> {
         IntoIter(self)
     }
 
-    pub fn iter(&self) -> Iter<'_, T> {
+    pub fn iter(&self) -> Iter<T> {
         Iter { next: self.head.as_deref() }
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<T> {
+        IterMut { next: self.head.as_deref_mut() }
     }
 }
 
@@ -65,6 +69,7 @@ pub struct IntoIter<T>(List<T>);
 impl<T> Iterator for IntoIter<T> {
     type Item = T;
     fn next(&mut self) -> Option<Self::Item> {
+        // access fields of a tuple struct numerically
         self.0.pop()
     }
 }
@@ -83,14 +88,8 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 }
 
-pub struct IterMut<'a, T: 'a> {
+pub struct IterMut<'a, T> {
     next: Option<&'a mut Node<T>>,
-}
-
-impl<T> List<T> {
-    pub fn iter_mut(&mut self) -> IterMut<T> {
-        IterMut { next: self.head.as_deref_mut() }
-    }
 }
 
 impl<'a, T> Iterator for IterMut<'a, T> {

--- a/src/second-final.md
+++ b/src/second-final.md
@@ -51,11 +51,11 @@ impl<T> List<T> {
         IntoIter(self)
     }
 
-    pub fn iter(&self) -> Iter<'_, T> {
+    pub fn iter(&self) -> Iter<T> {
         Iter { next: self.head.as_deref() }
     }
 
-    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+    pub fn iter_mut(&mut self) -> IterMut<T> {
         IterMut { next: self.head.as_deref_mut() }
     }
 }
@@ -93,7 +93,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 }
 
-pub struct IterMut<'a, T> {
+pub struct IterMut<'a, T: 'a> {
     next: Option<&'a mut Node<T>>,
 }
 
@@ -193,7 +193,6 @@ mod test {
         assert_eq!(iter.next(), Some(&mut 1));
     }
 }
-
 ```
 
 Getting beefier!


### PR DESCRIPTION
I also moved iter_mut instide default implementation of list, as there was no
reason to be separate. The other ones are not.

The consistency was ensured by doing a manual copy paste, since there is no
command to include an actual file here.
