### PR TITLE
test for null after each list

### DIFF
--- a/lists/src/second.rs
+++ b/lists/src/second.rs
@@ -176,6 +176,7 @@ mod test {
         assert_eq!(iter.next(), Some(&3));
         assert_eq!(iter.next(), Some(&2));
         assert_eq!(iter.next(), Some(&1));
+        assert_eq!(iter.next(), None);
     }
 
     #[test]
@@ -187,5 +188,6 @@ mod test {
         assert_eq!(iter.next(), Some(&mut 3));
         assert_eq!(iter.next(), Some(&mut 2));
         assert_eq!(iter.next(), Some(&mut 1));
+        assert_eq!(iter.next(), None);
     }
 }

--- a/lists/src/third.rs
+++ b/lists/src/third.rs
@@ -98,5 +98,6 @@ mod test {
         assert_eq!(iter.next(), Some(&3));
         assert_eq!(iter.next(), Some(&2));
         assert_eq!(iter.next(), Some(&1));
+        assert_eq!(iter.next(), None);
     }
 }

--- a/src/second-final.md
+++ b/src/second-final.md
@@ -180,6 +180,7 @@ mod test {
         assert_eq!(iter.next(), Some(&3));
         assert_eq!(iter.next(), Some(&2));
         assert_eq!(iter.next(), Some(&1));
+        assert_eq!(iter.next(), None);
     }
 
     #[test]
@@ -191,6 +192,7 @@ mod test {
         assert_eq!(iter.next(), Some(&mut 3));
         assert_eq!(iter.next(), Some(&mut 2));
         assert_eq!(iter.next(), Some(&mut 1));
+        assert_eq!(iter.next(), None);
     }
 }
 

--- a/src/second-iter-mut.md
+++ b/src/second-iter-mut.md
@@ -162,6 +162,7 @@ fn iter_mut() {
     assert_eq!(iter.next(), Some(&mut 3));
     assert_eq!(iter.next(), Some(&mut 2));
     assert_eq!(iter.next(), Some(&mut 1));
+    assert_eq!(iter.next(), None);
 }
 ```
 

--- a/src/second-iter.md
+++ b/src/second-iter.md
@@ -495,6 +495,7 @@ fn iter() {
     assert_eq!(iter.next(), Some(&3));
     assert_eq!(iter.next(), Some(&2));
     assert_eq!(iter.next(), Some(&1));
+    assert_eq!(iter.next(), None);
 }
 ```
 

--- a/src/third-basics.md
+++ b/src/third-basics.md
@@ -205,6 +205,7 @@ fn iter() {
     assert_eq!(iter.next(), Some(&3));
     assert_eq!(iter.next(), Some(&2));
     assert_eq!(iter.next(), Some(&1));
+    assert_eq!(iter.next(), None);
 }
 ```
 

--- a/src/third-final.md
+++ b/src/third-final.md
@@ -104,6 +104,7 @@ mod test {
         assert_eq!(iter.next(), Some(&3));
         assert_eq!(iter.next(), Some(&2));
         assert_eq!(iter.next(), Some(&1));
+        assert_eq!(iter.next(), None);
     }
 }
 ```


### PR DESCRIPTION
It was done sometime. I believe consistency makes sens here, it seems important
for a test to ensure that next's `next` also behaves correctly.

Sometime, two None are tested. I decided not to be that consistent, because this
redundancy seems heavy to read.
