### PR TITLE
Fix list descriptions in readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -37,8 +37,8 @@ reference, here's what we're going to be making:
 2. [An Ok Singly-Linked Stack](second.md)
 3. [A Persistent Singly-Linked Stack](third.md)
 4. [A Bad But Safe Doubly-Linked Deque](fourth.md)
-5. [An Unsafe Singly-Linked Queue](fifth.md)
-6. [TODO: An Ok Unsafe Doubly-Linked Deque](sixth.md)
+5. [An Ok Unsafe Doubly-Linked Deque](fifth.md)
+6. [A Production Unsafe Doubly-Linked Deque](sixth.md)
 7. [Bonus: A Bunch of Silly Lists](infinity.md)
 
 Just so we're all the same page, I'll be writing out all the commands that I


### PR DESCRIPTION
Names of links didn't match up to what they were pointing at, had a "TODO" where it really wasn't needed anymore?