### PR TITLE
Fix typo: Deinvent -> Reinvent

### DIFF
--- a/src/second.md
+++ b/src/second.md
@@ -4,7 +4,7 @@ In the previous chapter we wrote up a minimum viable singly-linked
 stack. However there's a few design decisions that make it kind of sucky.
 Let's make it less sucky. In doing so, we will:
 
-* Deinvent the wheel
+* Reinvent the wheel
 * Make our list able to handle any element type
 * Add peeking
 * Make our list iterable


### PR DESCRIPTION
I believe this is a typo, except you guys were referring to this very random website I found through googling "deinvent vs reinvent":
[De-invent don't re-invent!](https://www.wisdomandwonder.com/article/9105/de-invent-dont-re-invent)