### PR TITLE
Reword description about struct-wrapping

### DIFF
--- a/src/first-layout.md
+++ b/src/first-layout.md
@@ -312,15 +312,15 @@ Rust is mad at us again. We marked the `List` as public (because we want people
 to be able to use it), but not the `Node`. The problem is that the internals of
 an `enum` are totally public, and we're not allowed to publicly talk about
 private types. We could make all of `Node` totally public, but generally in Rust
-we favour keeping implementation details private. Let's make `List` a struct, so
+we favour keeping implementation details private. Let's wrap `List` inside a struct, so
 that we can hide the implementation details:
 
 ```rust ,ignore
-pub struct List {
+pub struct List {  // our new wrapper struct
     head: Link,
 }
 
-enum Link {
+enum Link {  // previously known as List
     Empty,
     More(Box<Node>),
 }


### PR DESCRIPTION
In the `first-layout.md`, there is a step where we convert `List` into a struct due to `pub enum` spilling its internals.

I've had a hard time wrapping my head around this step, and I believe it would be much clearer to the readers what we're doing if we explicitly say that we're wrapping the previous `List` enum inside the new `List` struct.