### PR TITLE
fifth-basics.md: Remove unnecessary dereference in pop()

### DIFF
--- a/src/fifth-basics.md
+++ b/src/fifth-basics.md
@@ -275,7 +275,6 @@ version:
 ```rust ,ignore
 pub fn pop(&mut self) -> Option<T> {
     self.head.take().map(|head| {
-        let head = *head;
         self.head = head.next;
 
         if self.head.is_none() {


### PR DESCRIPTION
The code would still work without L278 and it seems simpler.