### PR TITLE
sixth: Add sixth.rs, fix split_before and split_after edge cases

### DIFF
--- a/lists/src/lib.rs
+++ b/lists/src/lib.rs
@@ -3,6 +3,7 @@ pub mod second;
 pub mod third;
 pub mod fourth;
 pub mod fifth;
+pub mod sixth;
 
 pub mod silly1;
 pub mod silly2;

--- a/lists/src/sixth.rs
+++ b/lists/src/sixth.rs
@@ -1,14 +1,3 @@
-# Final Code
-
-I can't believe I actually just made you sit through me actually reimplementing std::collections::LinkedList from scratch, with all the fiddly little pedantry and mistakes I made along the way.
-
-I did it, the book is done, I can finally rest.
-
-Alright, here's all 1200 lines of our complete rewrite of  in all of its glory. This should be the same text as [this commit](https://github.com/contain-rs/linked-list/commit/5b69cc29454595172a5167a09277660342b78092).
-
-I'll put some polish and docs back on and publish 0.1.0 later.
-
-```rust
 use std::cmp::Ordering;
 use std::fmt::{self, Debug};
 use std::hash::{Hash, Hasher};
@@ -541,7 +530,7 @@ impl<'a, T> CursorMut<'a, T> {
                 // What self will become
                 let new_len = old_len - old_idx;
                 let new_front = self.cur;
-                let new_back = self.list.back;
+                let new_back = None;
                 let new_idx = Some(0);
 
                 // What the output will become
@@ -1214,5 +1203,40 @@ mod test {
 
         assert_eq!(from_front, re_reved);
     }
+
+    #[test]
+    fn split_before_first() {
+        let mut m: LinkedList<u32> = LinkedList::new();
+        m.extend([1, 2, 3, 4, 5, 6]);
+        let mut cursor = m.cursor_mut();
+        cursor.move_next();
+        assert_eq!(cursor.current(), Some(&mut 1));
+
+        let left = cursor.split_before();
+        assert!(left.is_empty());
+        assert!(left.front.is_none() && left.back.is_none());
+
+        assert_eq!(cursor.current(), Some(&mut 1));
+        assert_eq!(m.iter().cloned().collect::<Vec<_>>(), &[1, 2, 3, 4, 5, 6]);
+        assert_eq!(m.len(), 6);
+    }
+
+    #[test]
+    fn split_after_last() {
+        let mut m: LinkedList<u32> = LinkedList::new();
+        m.extend([1, 2, 3, 4, 5, 6]);
+        assert_eq!(m.iter().cloned().collect::<Vec<_>>(), &[1, 2, 3, 4, 5, 6]);
+        let mut cursor = m.cursor_mut();
+
+        cursor.move_prev();
+        assert_eq!(cursor.current(), Some(&mut 6));
+
+        let right = cursor.split_after();
+        assert!(right.is_empty());
+        assert!(right.front.is_none() && right.back.is_none());
+
+        assert_eq!(cursor.current(), Some(&mut 6));
+        assert_eq!(m.iter().cloned().collect::<Vec<_>>(), &[1, 2, 3, 4, 5, 6]);
+        assert_eq!(m.len(), 6);
+    }
 }
-```

--- a/src/sixth-cursors-impl.md
+++ b/src/sixth-cursors-impl.md
@@ -196,13 +196,16 @@ pub fn split_before(&mut self) -> LinkedList<T> {
 
             // What the output will become
             let output_len = old_len - new_len;
-            let output_front = self.list.front;
+            let mut output_front = self.list.front;
             let output_back = prev;
 
             // Break the links between cur and prev
             if let Some(prev) = prev {
                 (*cur.as_ptr()).front = None;
                 (*prev.as_ptr()).back = None;
+            } else {
+                // We're at the first node, need to unset the head we "optimistically" set before.
+                output_front = None;
             }
 
             // Produce the result:
@@ -232,6 +235,8 @@ Note that this if-let is handling the "normal case, but prev is the ghost" situa
 if let Some(prev) = prev {
     (*cur.as_ptr()).front = None;
     (*prev.as_ptr()).back = None;
+} else {
+    output_front = None;
 }
 ```
 
@@ -589,13 +594,16 @@ impl<'a, T> CursorMut<'a, T> {
 
                 // What the output will become
                 let output_len = old_len - new_len;
-                let output_front = self.list.front;
+                let mut output_front = self.list.front;
                 let output_back = prev;
 
                 // Break the links between cur and prev
                 if let Some(prev) = prev {
                     (*cur.as_ptr()).front = None;
                     (*prev.as_ptr()).back = None;
+                } else {
+                    // We're at the first node, need to unset the head we "optimistically" set before.
+                    output_front = None;
                 }
 
                 // Produce the result:
@@ -652,12 +660,15 @@ impl<'a, T> CursorMut<'a, T> {
                 // What the output will become
                 let output_len = old_len - new_len;
                 let output_front = next;
-                let output_back = self.list.back;
+                let mut output_back = self.list.back;
 
                 // Break the links between cur and next
                 if let Some(next) = next {
                     (*cur.as_ptr()).back = None;
                     (*next.as_ptr()).front = None;
+                } else {
+                    // We're at the first node, need to unset the tail we "optimistically" set before.
+                    output_back = None;
                 }
 
                 // Produce the result:


### PR DESCRIPTION
Fixes #238 

Both methods returned illegal lists when the cursor was at the first or last node respectively.

Note that I PR'd the same fix over on [contain-rs/linked-list](https://github.com/contain-rs/linked-list/pull/19) but the implementation is slightly different. Here, we are still setting the head/tail optimistically as before but remove it again later (when encountering the edge case):

```
let mut output_front = self.list.front;

if let Some(prev) = prev {
    (*cur.as_ptr()).front = None;
    (*prev.as_ptr()).back = None;
} else {
    // We're at the first node, need to unset the head we "optimistically" set before.
    output_front = None;
}
```
It seemed to me that this fit better into the flow of the article. Difference to the implementation I did before:
```
// We might be at the first node, in which case we don't want to set a new list.front but return an empty list.
let mut output_front = None;

if let Some(prev) = prev {
    (*cur.as_ptr()).front = None;
    (*prev.as_ptr()).back = None;
    output_front = self.list.front
}
```
My OCD prefers the latter version as we only ever set the head when it is actually required instead of setting and then maybe unsetting again. Let me know if you prefer any version and I will update any one of the PRs to unify the implementations, if desired.