### PR TITLE
modify second-iter-mut.md

### DIFF
--- a/src/second-iter-mut.md
+++ b/src/second-iter-mut.md
@@ -36,9 +36,10 @@ let mut list = List::new();
 list.push(1); list.push(2); list.push(3);
 
 let mut iter = list.iter();
-let x = iter.next().unwrap();
-let y = iter.next().unwrap();
-let z = iter.next().unwrap();
+let ref_to = iter.next().unwrap();
+let x = ref_to;
+let y = ref_to;
+let z = ref_to;
 ```
 
 Cool!


### PR DESCRIPTION
Cool!

This is *definitely fine* for shared references because the whole point is that
you can have tons of them at once. However mutable references *can't* coexist.
The whole point is that they're exclusive.

I think the current code is what this paragraph means.