### PR TITLE
Fix code snippet in sixth-cursors-intro.md

### DIFF
--- a/src/sixth-cursors-intro.md
+++ b/src/sixth-cursors-intro.md
@@ -22,8 +22,8 @@ Hey, we already have iterators! Can we use them for this? Kind of... but one of 
 ```rust ,ignore
 let mut list = ...;
 let iter = list.iter_mut();
-let elem1 = list.next();
-let elem2 = list.next();
+let elem1 = iter.next();
+let elem2 = iter.next();
 
 if elem1 == elem2 { ... }
 ```


### PR DESCRIPTION
Code snippet was calling next on an instance of linked list. I believe the author intended to call `iter.next()` instead of `list.next()`