### PR TITLE
Fixed typo in tests

### DIFF
--- a/src/third-basics.md
+++ b/src/third-basics.md
@@ -222,7 +222,7 @@ test second::test::peek ... ok
 test third::test::basics ... ok
 test third::test::iter ... ok
 
-test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured
 
 ```
 


### PR DESCRIPTION
In the tests 7 tests were run and only 6 were passed but none failed and there are 7 tests passed, hence fixed typo.